### PR TITLE
Testing for the feature (and others)

### DIFF
--- a/app/controllers/authz/bulk/controller_actions_controller.rb
+++ b/app/controllers/authz/bulk/controller_actions_controller.rb
@@ -5,41 +5,23 @@ module Authz
   class Bulk::ControllerActionsController < ApplicationController
 
     def create
-      if params[:create_all] = 'true'
-        ActiveRecord::Base.transaction do
-          @pending_actions = ::Authz::ControllerAction.pending
-          @pending_actions.each do |controller_action_hash|
-            ::Authz::ControllerAction.create!(
-              controller: controller_action_hash[:controller],
-              action: controller_action_hash[:action],
-            )
-          end
-        end
-        flash[:success] = "#{@pending_actions.count} actions successfully created!"
-        redirect_to root_path
-      else
-        flash[:notice] = 'Partial bulk creation not implemented yet'
-        redirect_to root_path
-      end
+      pending_actions = Authz::ControllerAction.create_all_pending!
+      flash[:success] = "#{pending_actions.size} actions successfully created!"
+      redirect_to root_path
     end
 
     def destroy
-      if params[:destroy_all] = 'true'
-        ActiveRecord::Base.transaction do
-          @stale_actions = ::Authz::ControllerAction.stale
-          @stale_actions.each do |controller_action_hash|
-            ::Authz::ControllerAction.find_by(
-              controller: controller_action_hash[:controller],
-              action: controller_action_hash[:action],
-            ).destroy!
-          end
+      ActiveRecord::Base.transaction do
+        @stale_actions = ::Authz::ControllerAction.stale
+        @stale_actions.each do |controller_action_hash|
+          ::Authz::ControllerAction.find_by(
+            controller: controller_action_hash[:controller],
+            action: controller_action_hash[:action],
+          ).destroy!
         end
-        flash[:success] = "#{@stale_actions.count} actions successfully destroyed!"
-        redirect_to root_path
-      else
-        flash[:notice] = 'Partial bulk deletion not implemented yet'
-        redirect_to root_path
       end
+      flash[:success] = "#{@stale_actions.count} actions successfully destroyed!"
+      redirect_to root_path
     end
 
   end

--- a/app/controllers/authz/rolables_controller.rb
+++ b/app/controllers/authz/rolables_controller.rb
@@ -4,6 +4,7 @@ module Authz
   # Handles the controller actions related to the rolables
   # @api private
   class RolablesController < ApplicationController
+
     def index
       @rolables = rolable.all.page(params[:page])
     end

--- a/app/models/authz/controller_action.rb
+++ b/app/models/authz/controller_action.rb
@@ -57,7 +57,7 @@ module Authz
       res
     end
 
-    # @return [Authz::ControllerAction]
+    # @return [Array<Authz::ControllerAction>]
     #         controller action instances reachable from the router but not present in the database
     # @api private
     # @see .reachable_controller_actions
@@ -89,6 +89,12 @@ module Authz
       stale
     end
 
+    # Creates all pending controller actions in the database.
+    # The creation either succeeds or fails completely
+    # @return [Array<Authz::ControllerAction>] all controller action instances
+    #         that have been created.
+    # @api private
+    # @see .pending
     def self.create_all_pending!
       transaction do
         pending.each do |pca|
@@ -108,7 +114,7 @@ module Authz
     # @return [String] description of a controller action, parsed through the
     #                  controller_metadata_service
     def description
-      Authz.controller_metadata_service.get_controller_action_description(self.controller, self.action)
+      Authz.metadata_service.get_controller_action_description(self.controller, self.action)
     end
 
     private

--- a/app/views/authz/home/index.html.slim
+++ b/app/views/authz/home/index.html.slim
@@ -9,7 +9,7 @@ section.section
         .content
           .card
             .card-content.has-text-centered
-              p.title.is-1 = number_with_delimiter @pending_controller_actions.count
+              p.title.is-1 = number_with_delimiter @pending_controller_actions.size
               p.subtitle Controller Actions to be created
               - if @pending_controller_actions.blank?
                 p Everything's up to date

--- a/app/views/authz/pending_controller_actions/index.html.slim
+++ b/app/views/authz/pending_controller_actions/index.html.slim
@@ -3,7 +3,7 @@
 - if @pending_controller_actions.present?
   = content_for :nav_links do
     .buttons
-      = authz_link_to 'Create all', bulk_controller_actions_create_path(create_all: true), { class: 'button is-primary', method: :post }, skip_scoping:  true
+      = authz_link_to 'Create all', bulk_controller_actions_create_path, { class: 'button is-primary', method: :post }, skip_scoping:  true
 
 
 section.section

--- a/lib/authz.rb
+++ b/lib/authz.rb
@@ -1,6 +1,6 @@
 require 'authz/engine'
 require 'authz/cache'
-require 'authz/yard_controller_metadata_service'
+require 'authz/yard_metadata_service'
 require 'authz/models/rolable'
 require 'authz/controllers/scoping_manager'
 require 'authz/controllers/authorization_manager'
@@ -57,7 +57,7 @@ module Authz
   @@cache = Authz::Cache
 
   mattr_reader :controller_metadata_service
-  @@controller_metadata_service = Authz::YardControllerMetadataService.new
+  @@controller_metadata_service = Authz::YardMetadataService.new
 
   # Allows the configuration of the gem using
   # block syntax

--- a/lib/authz.rb
+++ b/lib/authz.rb
@@ -56,8 +56,8 @@ module Authz
   # The attribute that points to the cache module
   @@cache = Authz::Cache
 
-  mattr_reader :controller_metadata_service
-  @@controller_metadata_service = Authz::YardMetadataService.new
+  mattr_reader :metadata_service
+  @@metadata_service = Authz::YardMetadataService.new
 
   # Allows the configuration of the gem using
   # block syntax

--- a/lib/authz/yard_metadata_service.rb
+++ b/lib/authz/yard_metadata_service.rb
@@ -3,26 +3,28 @@ module Authz
 
     def initialize
       @descriptions = {}
+      @controller_action_description_tag = :authz_description
 
       # Register Authz tag so that YARD can parse it
       YARD::Tags::Library.define_tag(
         "Authz controller action description",
-        :authz_description
+        controller_action_description_tag
       )
     end
 
     def get_controller_action_description(controller_name, action_name)
-      descriptions.fetch(action_symbol(controller_name, action_name)) do |as|
+      controller_action_symbol = controller_action_symbol(controller_name, action_name)
+      descriptions.fetch(controller_action_symbol) do |as|
         YARD.parse(controller_filename(controller_name))
 
-        description = YARD::Registry.at(as)&.tag(:authz_description)&.text
+        description = YARD::Registry.at(as)&.tag(controller_action_description_tag)&.text
         descriptions[as] = description
       end
     end
 
     private
 
-    attr_reader :descriptions
+    attr_reader :descriptions, :controller_action_description_tag
 
     def controller_filename(controller_name)
       Rails.root.join(
@@ -30,7 +32,7 @@ module Authz
       ).to_s
     end
 
-    def action_symbol(controller_name, action_name)
+    def controller_action_symbol(controller_name, action_name)
       controller_name
         .split('/')
         .map(&:camelize)

--- a/lib/authz/yard_metadata_service.rb
+++ b/lib/authz/yard_metadata_service.rb
@@ -1,5 +1,5 @@
 module Authz
-  class YardControllerMetadataService
+  class YardMetadataService
 
 
     def initialize

--- a/lib/authz/yard_metadata_service.rb
+++ b/lib/authz/yard_metadata_service.rb
@@ -1,7 +1,6 @@
 module Authz
   class YardMetadataService
 
-
     def initialize
       @descriptions = {}
 
@@ -17,7 +16,6 @@ module Authz
         YARD.parse(controller_filename(controller_name))
 
         description = YARD::Registry.at(as)&.tag(:authz_description)&.text
-
         descriptions[as] = description
       end
     end
@@ -39,5 +37,6 @@ module Authz
         .join('::')
         .concat("Controller\##{action_name}")
     end
+
   end
 end

--- a/spec/dummy/app/controllers/cities_controller.rb
+++ b/spec/dummy/app/controllers/cities_controller.rb
@@ -1,7 +1,7 @@
 class CitiesController < ApplicationController
   before_action :set_city, only: [:edit, :update, :destroy]
 
-  # GET /cities
+  # @authz.description Lists all the cities that the user can see
   def index
     authorize skip_scoping: true
     @cities = apply_authz_scopes on: City.all

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
   resources :reports
   resources :ratings, only: [:index, :new, :create, :destroy]
   resources :announcements, only: [:index, :new, :create, :destroy]
+  resources :photos
 end

--- a/spec/lib/authz/yard_metadata_service_spec.rb
+++ b/spec/lib/authz/yard_metadata_service_spec.rb
@@ -6,27 +6,29 @@ module Authz
       let(:controller_name) { 'folder/photos' }
       let(:action_name) { 'index' }
       let(:controller_filename) { "#{Rails.root}/app/controllers/#{controller_name}_controller.rb" }
-      let(:action_symbol) { "Folder::PhotosController##{action_name}" }
+      let(:controller_action_symbol) { "Folder::PhotosController##{action_name}" }
       let(:description) { 'my super description' }
       let(:tag) { instance_double(YARD::Tags::Tag, text: description) }
       let(:code_object) { instance_double(YARD::CodeObjects::MethodObject, tag: tag) }
 
       it 'should return the @authz.description from the documentation' do
         expect(YARD).to receive(:parse).with(controller_filename)
-        expect(YARD::Registry).to receive(:at).with(action_symbol).and_return code_object
+        expect(YARD::Registry).to(
+          receive(:at).with(controller_action_symbol).and_return code_object
+        )
         expect(
           metadata_service.get_controller_action_description(controller_name, action_name)
         ).to eq(description)
       end
 
       it 'should return nil when no @authz.description is present' do
-        expect(YARD::Registry).to receive(:at).with(action_symbol).and_return nil
+        expect(YARD::Registry).to receive(:at).with(controller_action_symbol).and_return nil
         expect(
           metadata_service.get_controller_action_description(controller_name, action_name)
         ).to be_nil
       end
 
-      context 'when we call the ' do
+      context 'when we call the method multiple times' do
         it 'should return the description from cache instead of parsing the file' do
           metadata_service.get_controller_action_description(controller_name, action_name)
           expect(YARD).not_to receive(:parse)

--- a/spec/lib/authz/yard_metadata_service_spec.rb
+++ b/spec/lib/authz/yard_metadata_service_spec.rb
@@ -1,0 +1,41 @@
+module Authz
+  describe YardMetadataService, type: :service do
+
+    describe '#get_controller_action_description' do
+      let(:metadata_service) { described_class.new }
+      let(:controller_name) { 'folder/photos' }
+      let(:action_name) { 'index' }
+      let(:controller_filename) { "#{Rails.root}/app/controllers/#{controller_name}_controller.rb" }
+      let(:action_symbol) { "Folder::PhotosController##{action_name}" }
+      let(:description) { 'my super description' }
+      let(:tag) { instance_double(YARD::Tags::Tag, text: description) }
+      let(:code_object) { instance_double(YARD::CodeObjects::MethodObject, tag: tag) }
+
+      it 'should return the @authz.description from the documentation' do
+        expect(YARD).to receive(:parse).with(controller_filename)
+        expect(YARD::Registry).to receive(:at).with(action_symbol).and_return code_object
+        expect(
+          metadata_service.get_controller_action_description(controller_name, action_name)
+        ).to eq(description)
+      end
+
+      it 'should return nil when no @authz.description is present' do
+        expect(YARD::Registry).to receive(:at).with(action_symbol).and_return nil
+        expect(
+          metadata_service.get_controller_action_description(controller_name, action_name)
+        ).to be_nil
+      end
+
+      context 'when we call the ' do
+        it 'should return the description from cache instead of parsing the file' do
+          metadata_service.get_controller_action_description(controller_name, action_name)
+          expect(YARD).not_to receive(:parse)
+          metadata_service.get_controller_action_description(controller_name, action_name)
+        end
+      end
+
+
+    end
+
+  end
+end

--- a/spec/models/authz/controller_action_spec.rb
+++ b/spec/models/authz/controller_action_spec.rb
@@ -210,7 +210,7 @@ module Authz
     describe 'Instance methods' do
       describe '#description' do
         let(:ca) { create(:authz_controller_action) }
-        let(:metadata_service) { Authz.controller_metadata_service }
+        let(:metadata_service) { Authz.metadata_service }
         let(:description) { 'foo' }
         it 'should call the configured metadata service to retrieve the description' do
           expect(metadata_service).to(

--- a/spec/models/authz/controller_action_spec.rb
+++ b/spec/models/authz/controller_action_spec.rb
@@ -132,6 +132,22 @@ module Authz
 
     end
 
+
+    describe 'Instance methods' do
+      describe '#description' do
+        let(:ca) { create(:authz_controller_action) }
+        let(:metadata_service) { Authz.controller_metadata_service }
+        let(:description) { 'foo' }
+        it 'should call the configured metadata service to retrieve the description' do
+          expect(metadata_service).to(
+            receive(:get_controller_action_description)
+              .with(ca.controller, ca.action).and_return(description)
+          )
+          expect(ca.description).to eq description
+        end
+      end
+    end
+
   end
 end
 


### PR DESCRIPTION
This PR contains:
- Rename YardControllerMetadataService to YardMetadataService to reflect that the service may be used anywhere.
- Add testing to Yard metadata service
- Refactor and test `ControllerAction#description`
- Create the `Authz::ControllerAction.create_all_pending!` method and refactor the bulk controller
- Other minor beautifications of the feature

TODO: [this PR](https://github.com/serodriguez68/authz/pull/18) contains a list of things to do before release.